### PR TITLE
Tent vias

### DIFF
--- a/pocketbone.brd
+++ b/pocketbone.brd
@@ -1007,7 +1007,7 @@ Please make sure your boards conform to these design rules.</description>
 <param name="mlMaxStopFrame" value="3mil"/>
 <param name="mlMinCreamFrame" value="0mil"/>
 <param name="mlMaxCreamFrame" value="0mil"/>
-<param name="mlViaStopLimit" value="0mil"/>
+<param name="mlViaStopLimit" value="15mil"/>
 <param name="srRoundness" value="0"/>
 <param name="srMinRoundness" value="0mil"/>
 <param name="srMaxRoundness" value="0mil"/>


### PR DESCRIPTION
This tents the majority of the vias on the board through adjusting the DRC rule. 

The vias near the USB connector are not tented, which would require some minor design adjustment to move the vias away from the USB pads. Drilled holes that are half-tented can result in peculiar fabrication defects due to the mask application process. 
